### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,9 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 before_script:
-  - composer install --no-interaction --prefer-source --dev
+  - composer install --no-interaction --prefer-source
 
-script: vendor/bin/phpunit --configuration phpunit.xml
+script: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "php": ">=5.4"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.0"
+    "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5"
   },
   "autoload": {
     "psr-4": {

--- a/tests/ScanTest.php
+++ b/tests/ScanTest.php
@@ -41,11 +41,11 @@ class ScanTest extends TestCase
             $result = $scanner->scanFile($file, false);
 
             if (strpos($file, '/samples/positive/') !== false) {
-                $this->assertTrue(!empty($result));
+                $this->assertNotEmpty($result);
             }
 
             if (strpos($file, '/samples/negative/') !== false) {
-                $this->assertTrue(empty($result));
+                $this->assertEmpty($result);
             }
         }
     }


### PR DESCRIPTION
# Changed log
- Set different PHPUnit versions to support different PHP versions.
- Remove `--dev` option because this option is deprecated in `composer` command.
- Remove `--configuration` option because the default PHPUnit config path is same as specific path.
- Using the current assertions to do the assertions.